### PR TITLE
Add navigation directory to all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 <body>
   <div class="site">
     {% include header.html %}
+    {% include directory.html %}
     {{ content }}
     {% include footer.html %}
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,8 +2,6 @@
 layout: default
 ---
 
-{% include directory.html %}
-
 <section class="posts">
   {% for post in paginator.posts %}
   <article class="post-entry">


### PR DESCRIPTION
Move directory.html include from home.html to default.html so the
navigation grid appears on every page, not just the homepage.

https://claude.ai/code/session_01V3dvU7p75U9dKnAWpidnN9